### PR TITLE
GJNS-36 [챌린지] 챌린지 관련 연관관계 수정

### DIFF
--- a/src/main/java/goojeans/harulog/category/domain/entity/Category.java
+++ b/src/main/java/goojeans/harulog/category/domain/entity/Category.java
@@ -1,14 +1,17 @@
 package goojeans.harulog.category.domain.entity;
 
+import goojeans.harulog.challenge.domain.entity.Challenge;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+
+import java.util.List;
 
 
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Category {
 
@@ -18,5 +21,18 @@ public class Category {
     private Long categoryId;
 
     @NotNull
+    @Column(unique = true)
     private String categoryName;
+
+    @OneToMany(mappedBy = "category")
+    private List<Challenge> challengeList;
+
+    //양방향 연관관계 편의 메서리
+    public void addChallenge(Challenge challenge) {
+        if (!this.categoryName.equals(challenge.getCategory().categoryName)) {
+            challenge.getCategory().challengeList.remove(challenge);
+        }
+        this.challengeList.add(challenge);
+        challenge.assignToCategory(this);
+    }
 }

--- a/src/main/java/goojeans/harulog/category/repository/CategoryRepository.java
+++ b/src/main/java/goojeans/harulog/category/repository/CategoryRepository.java
@@ -2,13 +2,12 @@ package goojeans.harulog.category.repository;
 
 import goojeans.harulog.category.domain.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    @Query("select c from Category c where c.categoryName = :name")
-    Optional<Category> findByCategoryName(@Param("name") String CategoryName);
+    Optional<Category> findByCategoryId(Long categoryId);
+
+    Optional<Category> findByCategoryName(String CategoryName);
 }

--- a/src/main/java/goojeans/harulog/challenge/domain/entity/Challenge.java
+++ b/src/main/java/goojeans/harulog/challenge/domain/entity/Challenge.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Entity
 @Builder
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Challenge extends BaseEntity {
 
@@ -40,7 +40,7 @@ public class Challenge extends BaseEntity {
     @NotNull
     private Timestamp endDate;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     @NotNull
     private Category category;
@@ -52,4 +52,8 @@ public class Challenge extends BaseEntity {
 
     @OneToMany(mappedBy = "challenge")
     private List<ChallengeUser> challengeUserList;
+
+    public void assignToCategory(Category category) {
+        this.category = category;
+    }
 }


### PR DESCRIPTION
[변경 사항]
- 챌린지-카테고리 일대일에서 다대일 양방향 연관관계로 변경
- 연관관계 편의 메서드 추가