### PR TITLE
GJNS-49 [Swagger] Swagger 도입 및 테스트 api 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/goojeans/harulog/config/SwaggerConfig.java
+++ b/src/main/java/goojeans/harulog/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package goojeans.harulog.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ *  Swagger 설정
+ */
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI(){
+        return new OpenAPI()
+                .info(new Info()
+                        .title("HaruLog API")
+                        .description("간편한 기록, 갓생살기 SNS HaruLog!")
+                        .version("1.0.0"));
+        // todo: Spring Security 적용 후, API 문서에 인증 정보 추가
+        // https://velog.io/@najiexx/Spring-Boot-3%EC%97%90-Swagger-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0springdoc-openapi
+    }
+}

--- a/src/main/java/goojeans/harulog/controller/FirstController.java
+++ b/src/main/java/goojeans/harulog/controller/FirstController.java
@@ -1,13 +1,28 @@
 package goojeans.harulog.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * http://localhost:8080/swagger-ui/index.html 로 접속하면 Swagger UI 확인 가능
+ */
 @RestController
 public class FirstController {
 
     @RequestMapping("/")
     public String test() {
         return "hello";
+    }
+
+    @GetMapping("/api/swagger-test")
+    @Operation(
+            summary = "Swagger 테스트 API",
+            description = "Swagger 테스트 API 입니다."
+    )
+    public ResponseEntity<String> swaggerTest() {
+        return ResponseEntity.ok("Swagger 테스트 API 입니다.");
     }
 }


### PR DESCRIPTION
[추가사항]
- swagger 의존성 추가
- swagger 설정 파일 (SwaggerConfig.java)
- swagger 확인을 위한 Test Api 작성 (FirstController.swaggerTest())

[확인사항]
- [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)로 접속하면 api 명세 확인 가능

[참고자료] - Swagger 어노테이션 참고자료 
- [블로그1](https://blog.jiniworld.me/91)
- [블로그2](https://velog.io/@mj3242/Swagger-3.x-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98-%EC%A0%95%EB%A6%AC)
- [GitHub문서](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations#openapi)