### PR TITLE
GJNS-71 [DockerFile] 크램폴린 배포 시 테스트 없이 빌드하도록 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN echo "systemProp.http.proxyHost=krmp-proxy.9rum.cc\nsystemProp.http.proxyPort=3128\nsystemProp.https.proxyHost=krmp-proxy.9rum.cc\nsystemProp.https.proxyPort=3128" > /root/.gradle/gradle.properties
 
 # gradlew를 이용한 프로젝트 필드
-RUN ./gradlew clean build
+RUN ./gradlew clean build -x test
 
 # 빌드 결과 jar 파일을 실행
 CMD ["java", "-jar", "-Dspring.profiles.active=dev", "/home/gradle/project/build/libs/harulog-1.0.jar"]


### PR DESCRIPTION
[변경사항]
- 테스트 없이 빌드하도록 변경
  - 빌드 할 때, 테스트 코드 실패 -> 아마 db 때문에 그런 것 같음.