### PR TITLE
GJNS-93 [채팅방 in] 채팅방에 들어갔을 때 메세지 조회 개수 변경

### DIFF
--- a/src/main/java/goojeans/harulog/chat/repository/CustomMessageRepository.java
+++ b/src/main/java/goojeans/harulog/chat/repository/CustomMessageRepository.java
@@ -12,4 +12,7 @@ public interface CustomMessageRepository {
 
     // 채팅방 메세지 조회 (이후 메세지)
     List<Message> findAfterMessagesWithPagination(String roomId, Long lastMessageId, int limit);
+
+    // 채팅방 메세지 조회 (마지막 메세지 포함해서 이후 메세지)
+    List<Message> findAfterMessagesWithPaginationIncludeLastMessage(String roomId, Long lastMessageId, int limit);
 }

--- a/src/main/java/goojeans/harulog/chat/repository/CustomMessageRepositoryImpl.java
+++ b/src/main/java/goojeans/harulog/chat/repository/CustomMessageRepositoryImpl.java
@@ -37,4 +37,16 @@ public class CustomMessageRepositoryImpl implements CustomMessageRepository{
                 .limit(limit)
                 .fetch();
     }
+
+    // 채팅방 메세지 조회 (마지막 메세지 포함해서 이후 메세지) : 오름차순 (과거~최신)
+    @Override
+    public List<Message> findAfterMessagesWithPaginationIncludeLastMessage(String roomId, Long lastMessageId, int limit) {
+        QMessage qMessage = QMessage.message;
+        return queryFactory.selectFrom(qMessage)
+                .where(qMessage.chatRoom.id.eq(roomId),
+                        qMessage.id.goe(lastMessageId)) // 메시지의 ID가 주어진 lastMessageId보다 크거나 같은 경우만 조회합니다. (goe: greater than or equal)
+                .orderBy(qMessage.id.asc())
+                .limit(limit)
+                .fetch();
+    }
 }

--- a/src/main/java/goojeans/harulog/chat/service/MessageService.java
+++ b/src/main/java/goojeans/harulog/chat/service/MessageService.java
@@ -11,11 +11,14 @@ import java.util.List;
 
 public interface MessageService {
 
-    // 메세지 id로부터 이전 메세지 30개씩 조회
-    List<Message> getMessagesBefore(ChatRoom chatroom, Long lastReadMessageId);
+    // 메세지 id로부터 이전 메세지 조회
+    List<Message> getMessagesBefore(ChatRoom chatroom, Long lastReadMessageId, int size);
 
-    // 메세지 id로부터 이후 메세지 30개씩 조회
-    List<Message> getMessagesAfter(ChatRoom chatroom, Long lastReadMessageId);
+    // 메세지 id로부터 이후 메세지 조회
+    List<Message> getMessagesAfter(ChatRoom chatroom, Long lastReadMessageId, int size);
+
+    // 마지막 메세지 id 포함해서 이후 메세지 조회
+    List<Message> getMessagesAfterIncludeLastMessage(ChatRoom chatroom, Long lastReadMessageId, int size);
 
     // 채팅방 메세지 조회 : 스크롤 올릴 때
     Response<MessageListDTO> getMessagesBeforeResponse(String roomId, Long lastReadMessageId);

--- a/src/test/java/goojeans/harulog/chat/service/MessageServiceTest.java
+++ b/src/test/java/goojeans/harulog/chat/service/MessageServiceTest.java
@@ -66,7 +66,7 @@ class MessageServiceTest {
     @DisplayName("채팅방 이전 메세지 조회")
     void getMessagesBeforeResponse() {
         // given
-        when(messageRepository.findBeforeMessagesWithPagination(chatRoom.getId(), message5.getId(), 30))
+        when(messageRepository.findBeforeMessagesWithPagination(chatRoom.getId(), message5.getId(), 20))
                 .thenReturn(List.of(message4, message3, message2, message1));
 
         // when
@@ -84,7 +84,7 @@ class MessageServiceTest {
     @DisplayName("채팅방 이전 메세지 조회 - 실패 (더 이상 메세지가 없음)")
     void getMessagesBeforeResponseFail() {
         // given
-        when(messageRepository.findBeforeMessagesWithPagination(chatRoom.getId(), message5.getId(), 30))
+        when(messageRepository.findBeforeMessagesWithPagination(chatRoom.getId(), message5.getId(), 20))
                 .thenReturn(List.of());
 
         // when
@@ -103,7 +103,7 @@ class MessageServiceTest {
     @DisplayName("채팅방 이후 메세지 조회")
     void getMessagesAfterResponse() {
         // given
-        when(messageRepository.findAfterMessagesWithPagination(chatRoom.getId(), message1.getId(), 30))
+        when(messageRepository.findAfterMessagesWithPagination(chatRoom.getId(), message1.getId(), 20))
                 .thenReturn(List.of(message2, message3, message4, message5));
 
         // when
@@ -121,7 +121,7 @@ class MessageServiceTest {
     @DisplayName("채팅방 이후 메세지 조회 - 실패 (더 이상 메세지가 없음)")
     void getMessagesAfterResponseFail() {
         // given
-        when(messageRepository.findAfterMessagesWithPagination(chatRoom.getId(), message1.getId(), 30))
+        when(messageRepository.findAfterMessagesWithPagination(chatRoom.getId(), message1.getId(), 20))
                 .thenReturn(List.of());
 
         // when


### PR DESCRIPTION
[변경사항]
- 이전에는 마지막 메세지 기준으로 이후 메세지 30개를 조회했었음.
  - 이렇게 하니까 다 읽은 메세지만 있는 채팅방에서 이전, 이후 메세지도 못 불러 옴.
- 마지막 읽었던 메세지 기준으로 이전 5개 + 마지막 메세지 포함 30개 => 총 최대 35개 조회하도록 변경